### PR TITLE
updated .Meme-template-container in App.css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -22,12 +22,18 @@
 }
 
 
-.Meme-template-container{
-  display: grid;
-  grid-template-columns: repeat(2, 1fr); /* Creates two equal columns */
-  gap: 16px; /* Space between grid items */
-  padding: 16px; 
+.Meme-template-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); /* Dynamic number of columns */
+    gap: 16px; /* Space between grid items */
+    padding: 16px;
 }
+  
+.Meme-template-container img {
+    width: 100%; /* Make the image fill the entire grid item width */
+    height: auto; /* Maintain the image aspect ratio */
+}
+  
 
 img {
   height: 100%;


### PR DESCRIPTION
I have updated the  .Meme-template-container in App.css so that the number of columns are dynamic to fit the width of the meme with minimum width of 200px and also changed the css for the image tags inside  .Meme-template-container so that the meme takes 100% width and the height is set automatically to adjust according to aspect ratio. The homepage looks much better than before 

## Previous Page:
![image](https://github.com/user-attachments/assets/fed9c48a-0eb0-42b9-be62-86c92b90c7f3)


## New Page:
![image](https://github.com/user-attachments/assets/d9a3dcbb-3dfe-444a-8a8e-65d13971b7ea)
